### PR TITLE
Add new data save sizes for Adobe Flash

### DIFF
--- a/FriishProduce/main.Designer.cs
+++ b/FriishProduce/main.Designer.cs
@@ -850,7 +850,9 @@ namespace FriishProduce
             resources.GetString("Flash_TotalSaveDataSize.Items1"),
             resources.GetString("Flash_TotalSaveDataSize.Items2"),
             resources.GetString("Flash_TotalSaveDataSize.Items3"),
-            resources.GetString("Flash_TotalSaveDataSize.Items4")});
+            resources.GetString("Flash_TotalSaveDataSize.Items4"),
+            resources.GetString("Flash_TotalSaveDataSize.Items5"),
+            resources.GetString("Flash_TotalSaveDataSize.Items6")});
             this.Flash_TotalSaveDataSize.Name = "Flash_TotalSaveDataSize";
             // 
             // Flash_UseSaveData

--- a/FriishProduce/main.resx
+++ b/FriishProduce/main.resx
@@ -3323,18 +3323,24 @@
     <value>False</value>
   </data>
   <data name="Flash_TotalSaveDataSize.Items" xml:space="preserve">
-    <value>4096</value>
+    <value>16384</value>
   </data>
   <data name="Flash_TotalSaveDataSize.Items1" xml:space="preserve">
-    <value>2048</value>
+    <value>8192</value>
   </data>
   <data name="Flash_TotalSaveDataSize.Items2" xml:space="preserve">
-    <value>1024</value>
+    <value>4096</value>
   </data>
   <data name="Flash_TotalSaveDataSize.Items3" xml:space="preserve">
-    <value>512</value>
+    <value>2048</value>
   </data>
   <data name="Flash_TotalSaveDataSize.Items4" xml:space="preserve">
+    <value>1024</value>
+  </data>
+  <data name="Flash_TotalSaveDataSize.Items5" xml:space="preserve">
+    <value>512</value>
+  </data>
+  <data name="Flash_TotalSaveDataSize.Items6" xml:space="preserve">
     <value>256</value>
   </data>
   <data name="Flash_TotalSaveDataSize.Location" type="System.Drawing.Point, System.Drawing">


### PR DESCRIPTION
Add 8192 kB and 16384 kB for Adobe Flash savedata saving.

These sizes are also compatible on Wii, and some Flash games needs more space for saving data.