### PR TITLE
Add MSX/MSX2 VC bases

### DIFF
--- a/FriishProduce/database.json
+++ b/FriishProduce/database.json
@@ -178,6 +178,15 @@
     { "title": "International Karate (USA)", "id": "C9YE" },
     { "title": "International Karate (EUR)", "id": "C9YP" }
   ],
+  "msx": [
+    { "title": "Aleste (JPN)", "id": "XABJ", "sysarch": "MSX2", "type": "ccf" },
+    { "title": "Eggy (JPN)", "id": "XAAJ", "sysarch": "MSX1", "type": "ccf" },
+    { "title": "Metal Gear (JPN)", "id": "XAFJ", "sysarch": "MSX2", "type": "raw" },
+    { "title": "Metal Gear 2: Solid Snake (JPN)", "id": "XAPJ", "sysarch": "MSX2", "type": "raw" },
+    { "title": "Road Fighter (JPN)", "id": "XAGJ", "sysarch": "MSX1", "type": "raw" },
+    { "title": "Space Manbow (JPN)", "id": "XAEJ", "sysarch": "MSX2", "type": "raw" },
+    { "title": "Yie-Gah-koutei no Gyakush: Yie Ar Kung-Fu 2 (JPN)", "id": "XADJ", "sysarch": "MSX1", "type": "raw" }
+  ],
   "flash": [
     { "title": "Flash Placeholder / Back in Nature", "id": "WNAP" }
   ]


### PR DESCRIPTION
Add some Microsoft MSX / MSX2 Virtual Console bases to the database for a future support for inject MSX/MSX2 VC games.

I also used some variables for these:
- **sysarch** tells what architecture of MSX is using the WAD (MSX1, MSX2)
- **type** tells how the WAD handles the ROM and other files (ccf, raw)

CCF are only used on Aleste and Eggy (both of them published on Wii by D4 Enterprise), which I documented on my Discord server.
All other later MSX/MSX2 VC games (published by Konami) use roms as-is (raw format). I also documented how Konami MSX/MSX2 VC games handle their ROMs.