### PR TITLE
Remove 16384 kB on Flash save size on Wii

### DIFF
--- a/FriishProduce/main.Designer.cs
+++ b/FriishProduce/main.Designer.cs
@@ -854,8 +854,7 @@ namespace FriishProduce
             resources.GetString("Flash_TotalSaveDataSize.Items2"),
             resources.GetString("Flash_TotalSaveDataSize.Items3"),
             resources.GetString("Flash_TotalSaveDataSize.Items4"),
-            resources.GetString("Flash_TotalSaveDataSize.Items5"),
-            resources.GetString("Flash_TotalSaveDataSize.Items6")});
+            resources.GetString("Flash_TotalSaveDataSize.Items5")});
             this.Flash_TotalSaveDataSize.Name = "Flash_TotalSaveDataSize";
             // 
             // Flash_UseSaveData

--- a/FriishProduce/main.resx
+++ b/FriishProduce/main.resx
@@ -3137,24 +3137,21 @@
     <value>False</value>
   </data>
   <data name="Flash_TotalSaveDataSize.Items" xml:space="preserve">
-    <value>16384</value>
-  </data>
-  <data name="Flash_TotalSaveDataSize.Items1" xml:space="preserve">
     <value>8192</value>
   </data>
-  <data name="Flash_TotalSaveDataSize.Items2" xml:space="preserve">
+  <data name="Flash_TotalSaveDataSize.Items1" xml:space="preserve">
     <value>4096</value>
   </data>
-  <data name="Flash_TotalSaveDataSize.Items3" xml:space="preserve">
+  <data name="Flash_TotalSaveDataSize.Items2" xml:space="preserve">
     <value>2048</value>
   </data>
-  <data name="Flash_TotalSaveDataSize.Items4" xml:space="preserve">
+  <data name="Flash_TotalSaveDataSize.Items3" xml:space="preserve">
     <value>1024</value>
   </data>
-  <data name="Flash_TotalSaveDataSize.Items5" xml:space="preserve">
+  <data name="Flash_TotalSaveDataSize.Items4" xml:space="preserve">
     <value>512</value>
   </data>
-  <data name="Flash_TotalSaveDataSize.Items6" xml:space="preserve">
+  <data name="Flash_TotalSaveDataSize.Items5" xml:space="preserve">
     <value>256</value>
   </data>
   <data name="Flash_TotalSaveDataSize.Location" type="System.Drawing.Point, System.Drawing">


### PR DESCRIPTION
This size (16384 kB / 16 MB) isn't working on Wii, setting save size to that value causes the error message "Not enough Wii system memory" even if we have enough NAND memory.