### PR TITLE
remove Aleste and Eggy from MSX VC base WADs

### DIFF
--- a/FriishProduce/database.json
+++ b/FriishProduce/database.json
@@ -168,13 +168,11 @@
     { "title": "International Karate (EUR)", "id": "C9YP" }
   ],
   "msx": [
-    { "title": "Aleste (JPN)", "id": "XABJ", "sysarch": "MSX2", "type": "ccf" },
-    { "title": "Eggy (JPN)", "id": "XAAJ", "sysarch": "MSX1", "type": "ccf" },
-    { "title": "Metal Gear (JPN)", "id": "XAFJ", "sysarch": "MSX2", "type": "raw" },
-    { "title": "Metal Gear 2: Solid Snake (JPN)", "id": "XAPJ", "sysarch": "MSX2", "type": "raw" },
-    { "title": "Road Fighter (JPN)", "id": "XAGJ", "sysarch": "MSX1", "type": "raw" },
-    { "title": "Space Manbow (JPN)", "id": "XAEJ", "sysarch": "MSX2", "type": "raw" },
-    { "title": "Yie-Gah-koutei no Gyakush: Yie Ar Kung-Fu 2 (JPN)", "id": "XADJ", "sysarch": "MSX1", "type": "raw" }
+    { "title": "Metal Gear (JPN)", "id": "XAFJ", "sysarch": "MSX2" },
+    { "title": "Metal Gear 2: Solid Snake (JPN)", "id": "XAPJ", "sysarch": "MSX2" },
+    { "title": "Road Fighter (JPN)", "id": "XAGJ", "sysarch": "MSX1" },
+    { "title": "Space Manbow (JPN)", "id": "XAEJ", "sysarch": "MSX2" },
+    { "title": "Yie-Gah-koutei no Gyakush: Yie Ar Kung-Fu 2 (JPN)", "id": "XADJ", "sysarch": "MSX1" }
   ],
   "flash": [
     { "title": "Flash Placeholder / Back in Nature", "id": "WNAP" }


### PR DESCRIPTION
These WADs i personally tried to inject on these (the only ones with used CCF instead of raw format) but on all games i have tried to inject, it only showed a black screen.

Because of this, only MSX VC bases published by Konami are injectable.
Also, i have removed the variable "type" since it's now useless for MSX, and i left only the base WADs which use roms as-is (raw format).

Small info about MSX/MSX2 VC - raw format (by Konami):
- MSX1 VC games store its rom as "SLOT1.ROM" in the 00000005.app file
- MSX2 VC games store its rom as "MEGAROM.ROM" in the 00000005.app file
- all MSX/MSX2 VC games have its save icon/title saved as "banner.bin" in the 00000005.app file, which interestly uses the same format like NeoGeo VC does.