### PR TITLE
Global: don't modify/empty Opera.arc (and Opera.arc.zlib) as an emanual file

### DIFF
--- a/FriishProduce/_classes/global.cs
+++ b/FriishProduce/_classes/global.cs
@@ -232,7 +232,6 @@ namespace FriishProduce
 
             string[] emanualFiles =
             {
-                "Opera.arc.zlib",
                 "emanual.arc",
                 "LZH8emanual.arc",
                 "LZ77emanual.arc",


### PR DESCRIPTION
We do this because Opera.arc (including Opera.arc.zlib) mustn't be touched, modified or emptyed by any way, otherwise will cause issues on some WADs, so let's remove that Opera.arc(.zlib) is an emanual file, because it actually isn't.

Small info about Opera.arc: https://wiibrew.org/wiki//tmp/opera.arc