### PR TITLE
revert to libWiiSharp for WAD un/packing, re-add libWiiSharp for U8 handling on Flash WADs

### DIFF
--- a/FriishProduce/_classes/u8.cs
+++ b/FriishProduce/_classes/u8.cs
@@ -1,7 +1,4 @@
-﻿using System.IO;
-using System.Windows.Forms;
-
-namespace FriishProduce
+﻿namespace FriishProduce
 {
     public class U8
     {
@@ -19,32 +16,6 @@ namespace FriishProduce
             Wii.Tools.SaveFileFromByteArray(u, output);
 
             if (deleteInput) System.IO.Directory.Delete(input, true);
-        }
-    }
-
-    public class WADs
-    {
-        public static void Unpack(string input, string output)
-        {
-            try { Directory.Delete(output, true); } catch { }
-            Directory.CreateDirectory(output);
-            
-            File.WriteAllBytes(Application.StartupPath + "\\key.bin",
-                Path.GetFileNameWithoutExtension(input).EndsWith("T") || Path.GetFileNameWithoutExtension(input).EndsWith("Q") ?
-                libWiiSharp.CommonKey.GetKoreanKey() : libWiiSharp.CommonKey.GetStandardKey());
-            Wii.WadUnpack.UnpackWad(input, output);
-            File.Delete(Application.StartupPath + "\\key.bin");
-        }
-
-        public static void Pack(string input, string output)
-        {
-            if (File.Exists(output)) File.Delete(output);
-
-            File.WriteAllBytes(Application.StartupPath + "\\key.bin",
-                Path.GetFileNameWithoutExtension(input).EndsWith("T") || Path.GetFileNameWithoutExtension(input).EndsWith("Q") ?
-                libWiiSharp.CommonKey.GetKoreanKey() : libWiiSharp.CommonKey.GetStandardKey());
-            Wii.WadPack.PackWad(input, output);
-            File.Delete(Application.StartupPath + "\\key.bin");
         }
     }
 }

--- a/FriishProduce/_classes/u8.cs
+++ b/FriishProduce/_classes/u8.cs
@@ -8,12 +8,34 @@
             Wii.U8.UnpackU8(input, output);
         }
 
+        public static void libWiiSharpUnpack(string input, string output)
+        {
+            using (libWiiSharp.U8 u = new libWiiSharp.U8())
+            {
+                u.LoadFile(input);
+                u.Extract(output);
+                u.Dispose();
+            }
+        }
+
         public static void Pack(string input, string output, bool deleteInput = true)
         {
             if (System.IO.File.Exists(output)) System.IO.File.Delete(output);
             var s = new int[3];
             var u = Wii.U8.PackU8(input, out s[0], out s[1], out s[2]);
             Wii.Tools.SaveFileFromByteArray(u, output);
+
+            if (deleteInput) System.IO.Directory.Delete(input, true);
+        }
+
+        public static void libWiiSharpPack(string input, string output, bool deleteInput = true)
+        {
+            using (libWiiSharp.U8 u = new libWiiSharp.U8())
+            {
+                u.CreateFromDirectory(input);
+                u.Save(output);
+                u.Dispose();
+            }
 
             if (deleteInput) System.IO.Directory.Delete(input, true);
         }

--- a/FriishProduce/main.cs
+++ b/FriishProduce/main.cs
@@ -1368,7 +1368,8 @@ namespace FriishProduce
                 // ----------------------------------------------------
                 else if (currentConsole == Platforms.Flash)
                 {
-                    await Task.Run(() => { U8.Unpack(Paths.WorkingFolder + "00000002.app", Paths.WorkingFolder_Content2); });
+                    // we're using libWiiSharp for unpack the U8 files on Flash WADs because Wii.cs breaks them...
+                    await Task.Run(() => { U8.libWiiSharpUnpack(Paths.WorkingFolder + "00000002.app", Paths.WorkingFolder_Content2); });
 
                     Injectors.Flash Flash = new Injectors.Flash() { SWF = input[0] };
                     Flash.ReplaceSWF();
@@ -1381,7 +1382,8 @@ namespace FriishProduce
                     if (Custom.Checked && tImg.Get()) tImg.CreateSave(Platforms.Flash);
                     if (Custom.Checked) Flash.InsertSaveData(SaveDataTitle.Lines);
 
-                    await Task.Run(() => { U8.Pack(Paths.WorkingFolder_Content2, Paths.WorkingFolder + "00000002.app"); });
+                    // we're using once again libWiiSharp for repack the U8 files on Flash WADs because Wii.cs breaks them...
+                    await Task.Run(() => { U8.libWiiSharpPack(Paths.WorkingFolder_Content2, Paths.WorkingFolder + "00000002.app"); });
                 }
 
                 // ----------------------------------------------------

--- a/FriishProduce/main.cs
+++ b/FriishProduce/main.cs
@@ -1034,6 +1034,7 @@ namespace FriishProduce
 
                 await Task.Run(() =>
                 {
+                    try { Directory.Delete(Paths.WorkingFolder, true); } catch { }
                     var RunningP_List = Process.GetProcessesByName("texreplace");
                     if (RunningP_List != null || RunningP_List.Length > 0)
                         foreach (var RunningP in RunningP_List)
@@ -1041,7 +1042,8 @@ namespace FriishProduce
 
                     if (Patch.Visible) input[0] = Global.ApplyPatch(input[0], input[1]);
 
-                    WADs.Unpack(input[2], Paths.WorkingFolder);
+                    w = WAD.Load(input[2]);
+                    w.Unpack(Paths.WorkingFolder);
                 });
 
                 // ----------------------------------------------------
@@ -1406,8 +1408,7 @@ namespace FriishProduce
                     w = f.ConvertWAD(w, NANDLoader.SelectedIndex, TitleID.Text.ToUpper());
                 }
 
-                if (!ForwarderMode) WADs.Pack(Paths.WorkingFolder, Paths.WorkingFolder + "out.wad");
-                if (!ForwarderMode) w.LoadFile(Paths.WorkingFolder + "out.wad");
+                if (!ForwarderMode) w.CreateNew(Paths.WorkingFolder);
                 if (RegionFree.Checked) w.Region = libWiiSharp.Region.Free;
                 w.FakeSign = true;
                 w.ChangeTitleID(LowerTitleID.Channel, TitleID.Text);


### PR DESCRIPTION
After a lot of trial and error, i noticed that the causes of Flash WAD injects produced with FriishProduce crashing the Wii is because of the WAD/U8 handling.

I reverted from Wii.cs (WadMii) to libWiiSharp for all WAD un/packing mechanisms, cause WadMii sometimes has issues with these (including the black screens on Flash and other VC systems).

About U8, for fix the HOME Menu crash on Flash injects, i reimplemented libWiiSharp's U8 extract/repack routines with separate commands and tell the main injector program to use libWiiSharp U8 handling for Flash injects only, and for the rest of VC systems, use Wii.cs (U8Mii) U8 handling.