### PR TITLE
db: add additional SNES VC LZ77/LZH8 bases

### DIFF
--- a/FriishProduce/database.json
+++ b/FriishProduce/database.json
@@ -160,6 +160,14 @@
             "wad_titles": ["Mario no Super Picross", "Mario's Super Picross"]
         },
 
+	{
+            "id": "00010001-4a434c__",
+            "region": [0, 1, 3],
+            "emu_ver": [1, 1, 1],
+            "titles": ["聖剣伝説２ シークレット オブ マナ", "Secret of Mana"],
+            "wad_titles": ["Seiken Densetsu 2", "Secret of Mana"]
+        },
+
         {
             "id": "00010001-4a4342__",
             "region": [0, 1, 5],

--- a/FriishProduce/database.json
+++ b/FriishProduce/database.json
@@ -168,6 +168,30 @@
             "wad_titles": ["Super Mario RPG"]
         },
 
+	{
+            "id": "00010001-4a4441__",
+            "region": [0, 1, 3],
+            "emu_ver": [2, 2, 2],
+            "titles": ["ファイナルファンタジーⅥ", "Final Fantasy III"],
+            "wad_titles": ["Final Fantasy VI", "Final Fantasy III"]
+        },
+		
+        {
+            "id": "00010001-4a4548__",
+            "region": [0, 1, 3],
+            "emu_ver": [2, 2, 2],
+            "titles": ["ロックマンＸ２", "Mega Man X2"],
+            "wad_titles": ["Rockman X2", "Mega Man X2"]
+        },
+		
+        {
+            "id": "00010001-4a4436__",
+            "region": [0, 1, 5],
+            "emu_ver": [2, 2, 2],
+            "titles": ["ファイヤー・ファイティング", "The Ignition Factor"],
+            "wad_titles": ["Fire Fighting", "Ignition Factor, The"]
+        },
+
         {
             "id": "00010001-4a4356__",
             "region": [0, 1, 3],


### PR DESCRIPTION
Added:

LZ77:
- Secret of Mana (USA/Europe/Japan)

LZH8:
- The Ignition Factor (USA/Europe/Japan)
- Final Fantasy III (USA/Europe/Japan)
- Mega Man X2 (USA/Europe/Japan; the only SNES VC game which emulates the Cx4 chip)